### PR TITLE
refactor: modal 조건문 binding에서 portal로 변경

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,5 +9,6 @@
   <body>
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
+    <div id="modal-root"></div>
   </body>
 </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@testing-library/react": "^14.0.0",
         "@types/jest": "^29.5.0",
         "@types/react": "^18.0.27",
-        "@types/react-dom": "^18.0.10",
+        "@types/react-dom": "^18.0.11",
         "@typescript-eslint/eslint-plugin": "^5.56.0",
         "@typescript-eslint/parser": "^5.56.0",
         "@vitejs/plugin-react": "^3.1.0",
@@ -2267,9 +2267,9 @@
       }
     },
     "node_modules/@types/react-dom": {
-      "version": "18.0.10",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.0.10.tgz",
-      "integrity": "sha512-E42GW/JA4Qv15wQdqJq8DL4JhNpB3prJgjgapN3qJT9K2zO5IIAQh4VXvCEDupoqAwnz0cY4RlXeC/ajX5SFHg==",
+      "version": "18.0.11",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.0.11.tgz",
+      "integrity": "sha512-O38bPbI2CWtgw/OoQoY+BRelw7uysmXbWvw3nLWO21H1HSh+GOlqPuXshJfjmpNlKiiSDG9cc1JZAaMmVdcTlw==",
       "dev": true,
       "dependencies": {
         "@types/react": "*"
@@ -11331,9 +11331,9 @@
       }
     },
     "@types/react-dom": {
-      "version": "18.0.10",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.0.10.tgz",
-      "integrity": "sha512-E42GW/JA4Qv15wQdqJq8DL4JhNpB3prJgjgapN3qJT9K2zO5IIAQh4VXvCEDupoqAwnz0cY4RlXeC/ajX5SFHg==",
+      "version": "18.0.11",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.0.11.tgz",
+      "integrity": "sha512-O38bPbI2CWtgw/OoQoY+BRelw7uysmXbWvw3nLWO21H1HSh+GOlqPuXshJfjmpNlKiiSDG9cc1JZAaMmVdcTlw==",
       "dev": true,
       "requires": {
         "@types/react": "*"

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@testing-library/react": "^14.0.0",
     "@types/jest": "^29.5.0",
     "@types/react": "^18.0.27",
-    "@types/react-dom": "^18.0.10",
+    "@types/react-dom": "^18.0.11",
     "@typescript-eslint/eslint-plugin": "^5.56.0",
     "@typescript-eslint/parser": "^5.56.0",
     "@vitejs/plugin-react": "^3.1.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import reactLogo from "./assets/react.svg";
+import MyModal from "./components/atoms/MyModal/MyModal";
 import "./App.css";
 
 function App() {
@@ -17,16 +18,12 @@ function App() {
       </div>
       <h1>Vite + React</h1>
       <div className="card">
-        <button onClick={() => setCount((count) => count + 1)}>
-          count is {count}
-        </button>
+        <button onClick={() => setCount((count) => count + 1)}>count is {count}</button>
         <p>
           Edit <code>src/App.tsx</code> and save to test HMR
         </p>
       </div>
-      <p className="read-the-docs">
-        Click on the Vite and React logos to learn more
-      </p>
+      <p className="read-the-docs">Click on the Vite and React logos to learn more</p>
     </div>
   );
 }

--- a/src/components/atoms/MyModal/MyModal.tsx
+++ b/src/components/atoms/MyModal/MyModal.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import styles from "./MyModal.module.css";
+import ReactDOM from "react-dom";
 import { XMarkIcon } from "@heroicons/react/24/solid";
 
 interface Props {
@@ -9,32 +10,29 @@ interface Props {
 }
 
 export default function MyModal({ isOpen, closeModal, children }: Props) {
+  if (!isOpen) {
+    return null;
+  }
+
   const handleOverlayClick = (e: React.MouseEvent<HTMLDivElement>) => {
     if (e.target === e.currentTarget) {
       closeModal();
     }
   };
 
-  return (
-    <>
-      {isOpen && (
-        <div
-          className={styles.modalOverlay}
-          onClick={handleOverlayClick}
-          data-testid="modalOverlay"
-        >
-          <div className="bg-back rounded-lg px-5 py-5">
-            <div className="flex justify-end mb-3">
-              <XMarkIcon
-                className="w-6 h-6 cursor-pointer"
-                onClick={closeModal}
-                data-testid="xMarkIcon"
-              />
-            </div>
-            <div className="flex flex-col items-center justify-center">{children}</div>
-          </div>
+  return ReactDOM.createPortal(
+    <div className={styles.modalOverlay} onClick={handleOverlayClick} data-testid="modalOverlay">
+      <div className="bg-back rounded-lg px-5 py-5">
+        <div className="flex justify-end mb-3">
+          <XMarkIcon
+            className="w-6 h-6 cursor-pointer"
+            onClick={closeModal}
+            data-testid="xMarkIcon"
+          />
         </div>
-      )}
-    </>
+        <div className="flex flex-col items-center justify-center">{children}</div>
+      </div>
+    </div>,
+    document.getElementById("modal-root") as Element,
   );
 }

--- a/src/components/atoms/MyModal/__tests__/MyModal.test.tsx
+++ b/src/components/atoms/MyModal/__tests__/MyModal.test.tsx
@@ -4,11 +4,24 @@ import { render, screen, fireEvent } from "@testing-library/react";
 import "@testing-library/jest-dom";
 
 describe("MyModal", () => {
+  let modalRoot: HTMLElement;
+
+  beforeEach(() => {
+    modalRoot = document.createElement("div");
+    modalRoot.setAttribute("id", "modal-root");
+    document.body.appendChild(modalRoot);
+  });
+
+  afterEach(() => {
+    document.body.removeChild(modalRoot);
+  });
+
   it("renders children when isOpen is true", () => {
     render(
       <MyModal isOpen={true} closeModal={() => {}}>
         <h1>Test Modal</h1>
       </MyModal>,
+      { container: modalRoot },
     );
     expect(screen.getByText("Test Modal")).toBeInTheDocument();
   });
@@ -18,17 +31,18 @@ describe("MyModal", () => {
       <MyModal isOpen={false} closeModal={() => {}}>
         <h1>Test Modal</h1>
       </MyModal>,
+      { container: modalRoot },
     );
     expect(screen.queryByText("Test Modal")).toBeNull();
   });
 
   it("calls closeModal when overlay is clicked", () => {
     const closeModalMock = jest.fn();
-
     render(
       <MyModal isOpen={true} closeModal={closeModalMock}>
         <h1>Test Modal</h1>
       </MyModal>,
+      { container: modalRoot },
     );
 
     const modalOverlay = screen.getByTestId("modalOverlay");
@@ -44,6 +58,7 @@ describe("MyModal", () => {
       <MyModal isOpen={true} closeModal={closeModalMock}>
         <h1>Test Modal</h1>
       </MyModal>,
+      { container: modalRoot },
     );
 
     const xMarkIcon = screen.getByTestId("xMarkIcon");

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "esNext",
     "useDefineForClassFields": true,
-    "lib": ["DOM", "DOM.Iterable", "esNext"],
+    "lib": ["DOM", "DOM.Iterable", "esNext", "dom", "es2017"],
     "allowJs": true,
     "skipLibCheck": true,
     "esModuleInterop": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "esNext",
     "useDefineForClassFields": true,
-    "lib": ["DOM", "DOM.Iterable", "esNext", "dom", "es2017"],
+    "lib": ["DOM", "DOM.Iterable", "esNext"],
     "allowJs": true,
     "skipLibCheck": true,
     "esModuleInterop": true,


### PR DESCRIPTION
`{isOpen && <div></div>` 형태에서 `ReactDOM.createPortal` 사용으로 변경